### PR TITLE
Avoid multiple submission

### DIFF
--- a/admin/CF7_AntiSpam_Admin_Customizations.php
+++ b/admin/CF7_AntiSpam_Admin_Customizations.php
@@ -472,6 +472,23 @@ class CF7_AntiSpam_Admin_Customizations {
 
 		/* Identity Protection */
 		add_settings_section(
+			'cf7a_mailbox_protection',
+			__( 'Mailbox Protection', 'cf7-antispam' ),
+			array( $this, 'cf7a_print_mailbox_protection' ),
+			'cf7a-settings'
+		);
+
+		/* Enable identity_protection */
+		add_settings_field(
+			'mailbox_protection_multiple_send',
+			__( 'Avoid multiple send', 'cf7-antispam' ),
+			array( $this, 'cf7a_mailbox_protection_multiple_send_callback' ),
+			'cf7a-settings',
+			'cf7a_mailbox_protection'
+		);
+
+		/* Identity Protection */
+		add_settings_section(
 			'cf7a_identity_protection',
 			__( 'Identity Protection', 'cf7-antispam' ),
 			array( $this, 'cf7a_print_identity_protection' ),
@@ -826,6 +843,12 @@ class CF7_AntiSpam_Admin_Customizations {
 	}
 
 	/** It prints the user protection info text */
+	public function cf7a_print_mailbox_protection() {
+		$expire = apply_filters( 'cf7a_resend_timeout', 5 );
+		printf( '<p>%s</p><p>%s%s</p>', esc_html__( 'When activated, this feature prevents consecutive email deliveries to the user\'s mailbox by imposing delay between each message.', 'cf7-antispam' ), $expire, __( ' seconds has been set as the resend timeout, check the documentation if you want to change it', 'cf7-antispam' ) );
+	}
+
+	/** It prints the user protection info text */
 	public function cf7a_print_identity_protection() {
 		printf( '<p>%s</p>', esc_html__( 'After monitoring and analysing some bots, I noticed that it is necessary to block the way bots collect (user) data from the website, otherwise protecting the form may have no effect. This also blocks some registrations, spam comments and other attacks', 'cf7-antispam' ) );
 	}
@@ -1104,7 +1127,10 @@ class CF7_AntiSpam_Admin_Customizations {
 		$new_input['honeyform_position']       = ! empty( $input['honeyform_position'] ) ? sanitize_title( $input['honeyform_position'] ) : 'wp_body_open';
 		$new_input['honeyform_excluded_pages'] = ! empty( $input['honeyform_excluded_pages'] ) ? cf7a_str_array_to_uint_array( $input['honeyform_excluded_pages'] ) : '';
 
-		/* honeyform */
+		/* identity protection */
+		$new_input['mailbox_protection_multiple_send'] = isset( $input['mailbox_protection_multiple_send'] ) ? 1 : 0;
+
+		/* identity protection */
 		$new_input['identity_protection_user'] = isset( $input['identity_protection_user'] ) ? 1 : 0;
 		$new_input['identity_protection_wp']   = isset( $input['identity_protection_wp'] ) ? 1 : 0;
 
@@ -1530,6 +1556,14 @@ class CF7_AntiSpam_Admin_Customizations {
 			__( 'Add', 'cf7-antispam' ),
 			$str_excluded,
 			__( 'Remove', 'cf7-antispam' ),
+		);
+	}
+
+	/** It creates a checkbox with the id of "cf7a_identity_protection_user_callback" */
+	public function cf7a_mailbox_protection_multiple_send_callback() {
+		printf(
+			'<input type="checkbox" id="mailbox_protection_multiple_send" name="cf7a_options[mailbox_protection_multiple_send]" %s />',
+			! empty( $this->options['mailbox_protection_multiple_send'] ) ? 'checked="true"' : ''
 		);
 	}
 

--- a/core/CF7_AntiSpam.php
+++ b/core/CF7_AntiSpam.php
@@ -302,6 +302,11 @@ class CF7_AntiSpam {
 				$this->loader->add_filter( 'wp_headers', $plugin_frontend, 'cf7a_protect_wp', 999 );
 			}
 
+			/* Will check if the form has been submitted more than once, blocking all emails that were sent after the first one for a period of 5 seconds */
+			if ( isset( $this->options['mailbox_protection_multiple_send'] ) && intval( $this->options['mailbox_protection_multiple_send'] ) === 1 ) {
+				$this->loader->add_action( 'wpcf7_before_send_mail', $plugin_frontend, 'cf7a_check_resend', 9, 3 );
+			}
+
 			/* It adds a CSS style to the page that hides the honeypot field */
 			if (
 				( isset( $this->options['check_honeypot'] ) && 1 === intval( $this->options['check_honeypot'] ) ) || ( isset( $this->options['check_honeyform'] ) && 1 === intval( $this->options['check_honeyform'] ) )

--- a/core/CF7_AntiSpam_Frontend.php
+++ b/core/CF7_AntiSpam_Frontend.php
@@ -275,6 +275,18 @@ class CF7_AntiSpam_Frontend {
 		printf( '<style>body div .wpcf7-form .%s{position:absolute;margin-left:-999em;}</style>', esc_attr( $form_class ) );
 	}
 
+	function generateHash( $length = 12 ) {
+		$characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$hash       = '';
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$randIndex = random_int( 0, strlen( $characters ) - 1 );
+			$hash     .= $characters[ $randIndex ];
+		}
+
+		return $hash;
+	}
+
 	/**
 	 * It adds hidden fields to the form
 	 *
@@ -296,6 +308,11 @@ class CF7_AntiSpam_Frontend {
 		/* add the timestamp if required */
 		if ( intval( $this->options['check_time'] ) === 1 ) {
 			$fields[ $prefix . '_timestamp' ] = cf7a_crypt( time(), $this->options['cf7a_cipher'] );
+		}
+
+		/* whenever required add the hash to the form to prevent multiple submissions */
+		if ( intval( $this->options['mailbox_protection_multiple_send'] ) === 1 ) {
+			$fields[ $prefix . 'hash' ] = $this->generateHash();
 		}
 
 		/* add the default hidden fields */


### PR DESCRIPTION
This pull request introduces functionality to the CF7 Antispam WordPress plugin, enhancing its mail handling mechanism. The primary goal is to prevent the resend of emails within a specified timeframe. Here's a brief overview of the changes:

**Hash Verification:**
The function now checks for the presence of an email hash ($_POST['_cf7a_hash']) in the submitted form data.
If the hash is missing, an error is added to the form submission results, and the form is marked with 'mail_hash_missing' status.
A response is set to inform the user: "Something went wrong. Please reload the page."

**Resend Control:**
An expiration time for email resend attempts is introduced. This value is adjustable using the 'cf7a_resend_timeout' filter (defaults to 5 seconds).
If a hash exists and a transient named "mail_sent_$hash" is present, the function prevents email resend and sets the form status to 'mail_sent_multiple.'
The response message indicates the waiting period: "Slow down, please wait [expire] seconds before resending."

**Transient Management:**
The transient "mail_sent_$hash" is deleted if it exists, ensuring a clean slate for each new email submission.
If the hash is valid and the transient doesn't exist, a new transient is set to mark the email as sent. The transient expires after the specified timeout.

**Form Abortion:**
If any issues are detected, the form abortion flag is set to true, preventing further processing.

**Filter Documentation**
The pull request introduces a new filter, 'cf7a_resend_timeout,' which allows developers to customize the resend timeout duration. This filter should return a numerical value representing the number of seconds.

close #18 