### PR TITLE
Fix/honeyform init

### DIFF
--- a/admin/CF7_AntiSpam_Admin_Customizations.php
+++ b/admin/CF7_AntiSpam_Admin_Customizations.php
@@ -1126,7 +1126,7 @@ class CF7_AntiSpam_Admin_Customizations {
 		/* honeyform */
 		$new_input['check_honeyform']          = isset( $input['check_honeyform'] ) ? 1 : 0;
 		$new_input['honeyform_position']       = ! empty( $input['honeyform_position'] ) ? sanitize_title( $input['honeyform_position'] ) : 'wp_body_open';
-		$new_input['honeyform_excluded_pages'] = ! empty( $input['honeyform_excluded_pages'] ) ? cf7a_str_array_to_uint_array( $input['honeyform_excluded_pages'] ) : '';
+		$new_input['honeyform_excluded_pages'] = ! empty( $input['honeyform_excluded_pages'] ) ? cf7a_str_array_to_uint_array( $input['honeyform_excluded_pages'] ) : array();
 
 		/* identity protection */
 		$new_input['mailbox_protection_multiple_send'] = isset( $input['mailbox_protection_multiple_send'] ) ? 1 : 0;

--- a/core/CF7_AntiSpam_Frontend.php
+++ b/core/CF7_AntiSpam_Frontend.php
@@ -154,8 +154,7 @@ class CF7_AntiSpam_Frontend {
 			return $content;
 		}
 
-		$cf7a_options = get_option( 'cf7a_options' );
-		if ( in_array( $current_id, $cf7a_options['honeyform_excluded_pages'] ) ) {
+		if ( is_array( $this->options['honeyform_excluded_pages'] ) && in_array( $current_id, $this->options['honeyform_excluded_pages'] ) ) {
 			// If the current post ID is excluded, return the original content
 			return $content;
 		}


### PR DESCRIPTION
@silas2209 on the wp forum reports that the honeyform when enabled without any exclusion crashes the website because the option is saved as a string

https://github.com/wp-blocks/cf7-antispam/blob/cce2c6be377e84d6840830db5ecafc77fd27ef19/admin/CF7_AntiSpam_Admin_Customizations.php#L1129

this pr should fix that